### PR TITLE
Allow any currency symbol via overloaded class.

### DIFF
--- a/src/Bitpay/Client/Client.php
+++ b/src/Bitpay/Client/Client.php
@@ -121,7 +121,7 @@ class Client implements ClientInterface
             ->setBtcPrice(array_key_exists('btcPrice', $data) ? $data['btcPrice'] : '')
             ->setPrice($data['price'])
             ->setTaxIncluded($data['taxIncluded'])
-            ->setCurrency(new \Bitpay\Currency($data['currency']))
+            ->setCurrency(new \Bitpay\CurrencyUnrestricted($data['currency']))
             ->setOrderId(array_key_exists('orderId', $data) ? $data['orderId'] : '')
             ->setInvoiceTime($invoiceTime)
             ->setExpirationTime($expirationTime)

--- a/src/Bitpay/CurrencyUnrestricted.php
+++ b/src/Bitpay/CurrencyUnrestricted.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Bitpay;
+
+class CurrencyUnrestricted extends Currency
+{
+  /**
+   * Overrides the parent method to allow any currency symbol to be set.
+   */
+  public function setCode($code)
+  {
+    $this->code = $code;
+
+    return $this;
+  }
+}


### PR DESCRIPTION
This is a backport from https://github.com/btcpayserver/btcpayserver-php-client/pull/46/

cc @Kukks 
