### PR TITLE
Fix Lets Encrypt root cert error

### DIFF
--- a/src/Bitpay/Client/Adapter/CurlAdapter.php
+++ b/src/Bitpay/Client/Adapter/CurlAdapter.php
@@ -103,7 +103,6 @@ class CurlAdapter implements AdapterInterface
             CURLOPT_TIMEOUT        => 10,
             CURLOPT_SSL_VERIFYPEER => 1,
             CURLOPT_SSL_VERIFYHOST => 2,
-            CURLOPT_CAINFO         => __DIR__.'/ca-bundle.crt',
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_FORBID_REUSE   => 1,
             CURLOPT_FRESH_CONNECT  => 1,


### PR DESCRIPTION
@NicolasDorier 

Do not use the custom ca-bundle.crt as it contains outdated certs and there is no obvious reason imo to why even use it at all. Normally the system ssl library is good enough for major SSL certs to work. Maybe Bitpay had some need for self signed certs or something to even do that.

Note: just did edit in the web UI and not delete the ca-bundle.crt file for now.

Context:
https://chat.btcpayserver.org/btcpayserver/pl/cm9itj98hfbr9jgiq4t38hkeuw

including the comments afterwards of another user geekme that tried this fix successfully.

Todo: after merging this somebody needs to do a WooCommerce plugin release, not sure who is in charge of that atm.